### PR TITLE
Resource paths now resolved relative to html file

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function updateDOM(file, config) {
     var localPath = resolvePath(node, config);
 
     if (localPath) {
-      $(node).attr('integrity', getFileHash(path.normalize(file.base + localPath), config.algo));
+      $(node).attr('integrity', getFileHash(path.join(path.dirname(file.path), localPath), config.algo));
     }
   }
 }


### PR DESCRIPTION
sri generation failed in my case where I had complex directory structure like this:
```
myApp
|-- gulpfile.js
|-- core
|   |-- scripts
|   |   `-- main.js
|   |-- styles
|   |   `-- main.css
|   `-- index.html
`-- hosts
    |-- electron
    |   |-- scripts
    |   |   `-- main.js
    |   `-- index.html
    `-- webapp
        |-- scripts
        |   `-- main.js
        `-- index.html

```
Upon debugging `index.js` I found paths to resources were being resolved relative to `gulpfile` or `cwd` (not sure). After this patch they are now resolved relative to `html` file in question.