### PR TITLE
Use cached cheerio object, if available.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,10 @@ const getFileHash = (fullPath, algorithm) => {
 };
 
 const updateDOM = (file, config) => {
-  const $ = cheerio.load(file.contents);
+    if (!file.cheerio) {		
+    file.cheerio = cheerio.load(file.contents)		
+  }
+  const $ = file.cheerio;
   const $candidates = $(config.selector);
   const resolver = config.relative ? resolveRelativePath : resolveAbsolutePath;
   const addIntegrityAttribute = (idx, node) => {


### PR DESCRIPTION
gulp-cheerio stores the `$` object returned by `cheerio.load()` in `file.cheerio` so, if it is available (in the case of a user running gulp-cheerio before gulp-src-hash), it may be best to use the cached object.

I'm open to any feedback on this. It might be worth adding the option to not use a cached resource as well.