### PR TITLE
Fixed cheerio encoding strings as HTML entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ const getFileHash = (fullPath, algorithm) => {
 };
 
 const updateDOM = (file, config) => {
-  const $ = cheerio.load(file.contents);
+  const $ = cheerio.load(file.contents, { decodeEntities: false });
   const $candidates = $(config.selector);
   const resolver = config.relative ? resolveRelativePath : resolveAbsolutePath;
   const addIntegrityAttribute = (idx, node) => {


### PR DESCRIPTION
Was causing a few issues with encoding HTML entities into JS unload events. Thought this may be useful for other people too.